### PR TITLE
Complete Refactor

### DIFF
--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -1879,7 +1879,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
   uint8_t num_bytes_write_idx = 0;
   boolean gotColon = false;
 
-  // treat it as an error if (num_bytes_write_idx == 15) // overflow
+  // treat it as an error if (num_bytes_write_idx == 8) // overflow
   // or if if (current_time - previous_time >= interval) // timeout
   // update current_time on an ongoing basis
   // assign previous_time to current_time anytime a byte is received to prolong timeout
@@ -1897,7 +1897,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
       printDebugWindow();
     }
     
-    while(bytesAvailable > 0){
+    while(bytesAvailable > 0 && !gotColon){
       bytesAvailable--;
       previous_time = current_time;
       unsigned char b = stream->read() & 0xff;

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -1772,6 +1772,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
   numIncomingBytesPending = strtoul(num_bytes_str, &temp, 10);
   if (*temp != '\0'){
     // TODO: complain loudly if this happens
+    numIncomingBytesPending = 0;
     return; // failed to parse length
   }
 }

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -2494,7 +2494,7 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
       break;
     case 'D':
       if(c == ',') {        
-        // Serial.print('!');
+        Serial.print('!');
         ret = true; // this is the only way it can be true
       }
       // unconditionally clear the state machine after ','

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -2237,6 +2237,7 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
       else { pursuitString = 0; lastCharAccepted = ' '; }
       break;      
     case 'I':
+                             //                         v v  v
       if(pursuitDepth == 2){ // after the first I in 'WIFI DISCONNECT'
                              //                       0123456789abcde
         if(c == 'F') { lastCharAccepted = c; pursuitDepth++; }
@@ -2246,7 +2247,7 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
         if(c == ' ') { lastCharAccepted = c; pursuitDepth++; }
         else { pursuitString = 0; lastCharAccepted = ' '; }
       }
-      else if(pursuitDepth == 7){
+      else if(pursuitDepth == 7){ // after the third I in 'WIFI DISCONNECT'
         if(c == 'S') { lastCharAccepted = c; pursuitDepth++; }
         else { pursuitString = 0; lastCharAccepted = ' '; }        
       }
@@ -2268,17 +2269,18 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
       if(c == 'C') { lastCharAccepted = c; pursuitDepth++; }
       else { pursuitString = 0; lastCharAccepted = ' '; }
       break;
-    case 'C':
-      if(pursuitDepth == 0x9){ // after the first N in 'WIFI DISCONNECT'
+    case 'C':                  //                                v    v
+      if(pursuitDepth == 0x9){ // after the first C in 'WIFI DISCONNECT'
                                //                       0123456789abcde
         if(c == 'O') { lastCharAccepted = c; pursuitDepth++; }
         else { pursuitString = 0; lastCharAccepted = ' '; }
       }
-      else if(pursuitDepth == 0xe){ // after the second N in 'WIFI DISCONNECT'
+      else if(pursuitDepth == 0xe){ // after the second C in 'WIFI DISCONNECT'
         if(c == 'T') { 
           // this is a goal state
           wifi_is_connected = false;
         }
+        // unconditionally clear the state machine after 'T'
         pursuitString = 0; lastCharAccepted = ' ';
       }
       else { pursuitString = 0; lastCharAccepted = ' '; }
@@ -2286,8 +2288,8 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
     case 'O':
       if(c == 'N') { lastCharAccepted = c; pursuitDepth++; }
       else { pursuitString = 0; lastCharAccepted = ' '; }
-      break;  
-    case 'N':
+      break;
+    case 'N':                  //                                  vv
       if(pursuitDepth == 0xb){ // after the first N in 'WIFI DISCONNECT'
                                //                       0123456789abcde
         if(c == 'N') { lastCharAccepted = c; pursuitDepth++; }

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -640,8 +640,7 @@ void ESP8266_AT_Client::flush(){
 
 /** Stop client
  */
-void ESP8266_AT_Client::stop(){
-
+void ESP8266_AT_Client::stop(){  
   if(socket_connected || (socket_type == ESP8266_UDP) || listener_started){
 
     // set up an AT command and send it
@@ -676,6 +675,8 @@ void ESP8266_AT_Client::stop(){
   while(num_consumed_bytes_in_input_buffer > 0){
     readFromInputBuffer();
   }
+
+  socket_connected = false;
 
 }
 

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -217,10 +217,12 @@ boolean ESP8266_AT_Client::reset(void){
   while(!error_flag && !ready_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }       
+    }   
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -322,9 +324,11 @@ int ESP8266_AT_Client::connect(const char *host, uint16_t port, esp8266_connect_
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }
     }
 
     if (current_millis - previous_millis >= interval) {
@@ -391,9 +395,11 @@ boolean ESP8266_AT_Client::setMacAddress(uint8_t * mac_address){
     while(!error_flag && !ok_flag && !timeout_flag){
       current_millis = millis();
 
-      int16_t b = streamReadChar();
-      if(b > 0){
-        previous_millis = current_millis;      
+      if(stream->available() > 0){
+        int16_t b = streamReadChar();
+        if(b > 0){
+          previous_millis = current_millis;      
+        }
       }
 
       if (current_millis - previous_millis >= interval) {
@@ -433,10 +439,12 @@ boolean ESP8266_AT_Client::listen(uint16_t port){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -467,10 +475,12 @@ boolean ESP8266_AT_Client::listen(uint16_t port){
     while(!error_flag && !ok_flag && !timeout_flag){
       current_millis = millis();
 
-      int16_t b = streamReadChar();
-      if(b > 0){
-        previous_millis = current_millis;      
-      }          
+      if(stream->available() > 0){
+        int16_t b = streamReadChar();
+        if(b > 0){
+          previous_millis = current_millis;      
+        }          
+      }
 
       if (current_millis - previous_millis >= interval) {
         timeout_flag = true;
@@ -513,10 +523,12 @@ boolean ESP8266_AT_Client::configureSoftAP(const char *ssid, const char *pwd, ui
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -550,10 +562,12 @@ boolean ESP8266_AT_Client::sleep(uint8_t mode){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -599,10 +613,12 @@ boolean ESP8266_AT_Client::setStaticIPAddress(uint32_t ipAddress, uint32_t netMa
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -633,10 +649,12 @@ boolean ESP8266_AT_Client::setDHCP(void){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -695,14 +713,16 @@ size_t ESP8266_AT_Client::write(const uint8_t *buf, size_t sz){
   while(!error_flag && !ok_to_exit && !timeout_flag){ // TODO: add timeout, else this _could_ be an infinite loop
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }
 
-    if(!wroteData && (b == '>')){ // this is the trigger to write bytes to the output stream
-      ret = streamWrite(buf, sz); // pass it along
-      wroteData = true;
+      if(got_ok && !wroteData && (b == '>')){ // this is the trigger to write bytes to the output stream
+        ret = streamWrite(buf, sz); // pass it along
+        wroteData = true;
+      }      
     }
 
     if(ok_flag){
@@ -829,10 +849,12 @@ void ESP8266_AT_Client::stop(){
     while(!error_flag && !ok_flag && !timeout_flag){
       current_millis = millis();
 
-      int16_t b = streamReadChar();
-      if(b > 0){
-        previous_millis = current_millis;      
-      }          
+      if(stream->available() > 0){
+        int16_t b = streamReadChar();
+        if(b > 0){
+          previous_millis = current_millis;      
+        } 
+      }         
 
       if (current_millis - previous_millis >= interval) {
         timeout_flag = true;
@@ -892,49 +914,51 @@ boolean ESP8266_AT_Client::scanForAccessPoint(char * ssid, ap_scan_result_t * re
   while(!timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;
-      if(!inside_result){
-        if(b == '('){
-          inside_quotes = false;
-          inside_result = true;
-          line_idx = 0;
-          line[0] = 0;      
-        }
-        else if(ok_flag || error_flag){ // you got OK or ERROR and you're not in a scan result
-          break;                        // either we got the result or we didn't, but in any case we're done
-        }
-      }
-      else if(inside_result){
-        if(!inside_quotes && (b == ')')){
-          inside_result = false;
-          // process the line
-          ap_scan_result_t res = {0};
-          parseScanResult(&res, line);
-          result_number++;
-          if((strcmp(&(res.ssid[0]), ssid) == 0) && (res.rssi > max_rssi)){
-            *result = res;
-            max_rssi = res.rssi;
-            ret = true;
-          }  
-        }
-        else {
-          if(b == '"'){
-            inside_quotes = !inside_quotes;
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;
+        if(!inside_result){
+          if(b == '('){
+            inside_quotes = false;
+            inside_result = true;
+            line_idx = 0;
+            line[0] = 0;      
           }
+          else if(ok_flag || error_flag){ // you got OK or ERROR and you're not in a scan result
+            break;                        // either we got the result or we didn't, but in any case we're done
+          }
+        }
+        else if(inside_result){
+          if(!inside_quotes && (b == ')')){
+            inside_result = false;
+            // process the line
+            ap_scan_result_t res = {0};
+            parseScanResult(&res, line);
+            result_number++;
+            if((strcmp(&(res.ssid[0]), ssid) == 0) && (res.rssi > max_rssi)){
+              *result = res;
+              max_rssi = res.rssi;
+              ret = true;
+            }  
+          }
+          else {
+            if(b == '"'){
+              inside_quotes = !inside_quotes;
+            }
 
-          // if there is still space in the buffer enqueue b
-          if(line_idx < 127){ // line[127] must always be zero, and we're about to write two consecutive locations
-            line[line_idx++] = b;  // add a character, advance the write index
-            line[line_idx] = '\0'; // and enforce a null terminator
+            // if there is still space in the buffer enqueue b
+            if(line_idx < 127){ // line[127] must always be zero, and we're about to write two consecutive locations
+              line[line_idx++] = b;  // add a character, advance the write index
+              line[line_idx] = '\0'; // and enforce a null terminator
+            }
           }
         }
-      }
-      // otherwise you can ignore the character
-      // because you are not inside results
-      // and you have not just seen a '('
-    }          
+        // otherwise you can ignore the character
+        // because you are not inside results
+        // and you have not just seen a '('
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -981,47 +1005,49 @@ boolean ESP8266_AT_Client::scanAccessPoints(ap_scan_result_t * results, uint8_t 
   while(!timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;
-      if(!inside_result){
-        if(b == '('){
-          inside_quotes = false;
-          inside_result = true;
-          line_idx = 0;
-          line[0] = 0;      
-        }
-        else if(ok_flag || error_flag){ // you got OK or ERROR and you're not in a scan result
-                                        // either we got the result or we didn't, but in any case we're done
-          ret = ok_flag;                // if we got 'OK' then the result is good
-          break;
-        }
-      }
-      else if(inside_result){
-        if(!inside_quotes && (b == ')')){
-          inside_result = false;
-          if(result_number < max_num_results){
-            // process the line, but only if there's space for the result          
-            parseScanResult(&(results[result_number]), line);            
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;
+        if(!inside_result){
+          if(b == '('){
+            inside_quotes = false;
+            inside_result = true;
+            line_idx = 0;
+            line[0] = 0;      
           }
-          result_number++;
-        }
-        else {
-          if(b == '"'){
-            inside_quotes = !inside_quotes;
+          else if(ok_flag || error_flag){ // you got OK or ERROR and you're not in a scan result
+                                          // either we got the result or we didn't, but in any case we're done
+            ret = ok_flag;                // if we got 'OK' then the result is good
+            break;
           }
+        }
+        else if(inside_result){
+          if(!inside_quotes && (b == ')')){
+            inside_result = false;
+            if(result_number < max_num_results){
+              // process the line, but only if there's space for the result          
+              parseScanResult(&(results[result_number]), line);            
+            }
+            result_number++;
+          }
+          else {
+            if(b == '"'){
+              inside_quotes = !inside_quotes;
+            }
 
-          // if there is still space in the buffer enqueue b
-          if(line_idx < 127){ // line[127] must always be zero, and we're about to write two consecutive locations
-            line[line_idx++] = b;  // add a character, advance the write index
-            line[line_idx] = '\0'; // and enforce a null terminator
+            // if there is still space in the buffer enqueue b
+            if(line_idx < 127){ // line[127] must always be zero, and we're about to write two consecutive locations
+              line[line_idx++] = b;  // add a character, advance the write index
+              line[line_idx] = '\0'; // and enforce a null terminator
+            }
           }
         }
-      }
-      // otherwise you can ignore the character
-      // because you are not inside results
-      // and you have not just seen a '('
-    }          
+        // otherwise you can ignore the character
+        // because you are not inside results
+        // and you have not just seen a '('
+      }      
+    }    
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1101,25 +1127,27 @@ boolean ESP8266_AT_Client::getRemoteIp(uint32_t * ip){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-      if(b == '"'){
-        num_quotes++;
-      }
-      
-      if((num_quotes == 3) && (b != '"')){ // don't buffer the leading '"'
-        if(remote_ip_str_idx < 15){
-          remote_ip_str[remote_ip_str_idx++] = b;
-          remote_ip_str[remote_ip_str_idx] = '\0';
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+        if(b == '"'){
+          num_quotes++;
         }
-      }
-      else if(num_quotes == 4){
-        num_quotes++;
-        ret = stringToIpUint32((char *) remote_ip_str, ip);
-      }
-      
-    }    
+        
+        if((num_quotes == 3) && (b != '"')){ // don't buffer the leading '"'
+          if(remote_ip_str_idx < 15){
+            remote_ip_str[remote_ip_str_idx++] = b;
+            remote_ip_str[remote_ip_str_idx] = '\0';
+          }
+        }
+        else if(num_quotes == 4){
+          num_quotes++;
+          ret = stringToIpUint32((char *) remote_ip_str, ip);
+        }
+        
+      }    
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1158,13 +1186,15 @@ uint8_t ESP8266_AT_Client::connected(boolean actively_check){
     while(!error_flag && !ok_flag && !timeout_flag){
       current_millis = millis();
 
-      int16_t b = streamReadChar();
-      if(b > 0){
-        previous_millis = current_millis;      
-        if(b == '4'){ // STATUS:4 means disconnected
-          socket_connected = false;
-          ret = 0;
-        }      
+      if(stream->available() > 0){
+        int16_t b = streamReadChar();
+        if(b > 0){
+          previous_millis = current_millis;      
+          if(b == '4'){ // STATUS:4 means disconnected
+            socket_connected = false;
+            ret = 0;
+          }      
+        }
       }
 
       if (current_millis - previous_millis >= interval) {
@@ -1216,31 +1246,33 @@ boolean ESP8266_AT_Client::getIPAddress(char * ip_str, char * gateway_str, char 
 
     current_millis = millis();
     
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis; 
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis; 
 
-      if(b == '"'){
-        num_quotes++;
-        switch(num_quotes){
-        case 1: write_ptr = ip_str; write_idx = 0; break;
-        case 2: wrote_ipstr = true; break;
-        case 3: write_ptr = gateway_str;  write_idx = 0; break;
-        case 4: wrote_gateway_str = true; break;
-        case 5: write_ptr = netmask_str;  write_idx = 0; break;
-        case 6: wrote_netmask_str = true; break;
-        default: write_ptr = NULL; write_idx = 0;
-        }                  
-      }
-      else if(write_ptr != NULL){ // write pointer was set and b is != '"'     
-        // IP addresses can't be longer than "255.255.255.255" (15 characters)
-        // so write_idx should never obtain a value > 15
-        if(write_idx < 15){
-          write_ptr[write_idx++] = b;  // NOTE: this is _still_ dangerous if the passed pointers don't have enough space
-          write_ptr[write_idx] = '\0'; //enforce NULL terminate
+        if(b == '"'){
+          num_quotes++;
+          switch(num_quotes){
+          case 1: write_ptr = ip_str; write_idx = 0; break;
+          case 2: wrote_ipstr = true; break;
+          case 3: write_ptr = gateway_str;  write_idx = 0; break;
+          case 4: wrote_gateway_str = true; break;
+          case 5: write_ptr = netmask_str;  write_idx = 0; break;
+          case 6: wrote_netmask_str = true; break;
+          default: write_ptr = NULL; write_idx = 0;
+          }                  
         }
-      }
-    }        
+        else if(write_ptr != NULL){ // write pointer was set and b is != '"'     
+          // IP addresses can't be longer than "255.255.255.255" (15 characters)
+          // so write_idx should never obtain a value > 15
+          if(write_idx < 15){
+            write_ptr[write_idx++] = b;  // NOTE: this is _still_ dangerous if the passed pointers don't have enough space
+            write_ptr[write_idx] = '\0'; //enforce NULL terminate
+          }
+        }
+      }  
+    }      
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1408,25 +1440,27 @@ boolean ESP8266_AT_Client::getMacAddress(char * mac_str){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;
-      if(b == ','){
-        num_commas++;
-      }
-      else if(b == '"'){
-        num_quotes++;
-      }
-
-      if(num_commas == 4){ // station MAC is the last one reported (i.e. after the 4th comma)
-        if((b != '"') && (num_quotes == 7)){ // betweeb 7th and 8th quotes
-          // worst case mac address is FF:FF:FF:FF:FF:FF (17 characters)
-          if(write_idx < 17){ // [16] is the last viable write location
-            mac_str[write_idx++] = b;
-            mac_str[write_idx] = '\0';
-          }
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;
+        if(b == ','){
+          num_commas++;
         }
-      }         
+        else if(b == '"'){
+          num_quotes++;
+        }
+
+        if(num_commas == 4){ // station MAC is the last one reported (i.e. after the 4th comma)
+          if((b != '"') && (num_quotes == 7)){ // betweeb 7th and 8th quotes
+            // worst case mac address is FF:FF:FF:FF:FF:FF (17 characters)
+            if(write_idx < 17){ // [16] is the last viable write location
+              mac_str[write_idx++] = b;
+              mac_str[write_idx] = '\0';
+            }
+          }
+        }         
+      }
     }
 
     if (current_millis - previous_millis >= interval) {
@@ -1474,10 +1508,12 @@ boolean ESP8266_AT_Client::getHostByName(const char *hostname, uint32_t *ip, uin
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
   
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1575,10 +1611,7 @@ void ESP8266_AT_Client::flushInput(){
 
   if(bytesAvailable > 0){  
     while(stream->available() > 0){    
-      int chr = streamReadChar();
-      if(chr == -1){
-        continue;
-      }
+      int16_t chr = streamReadChar();
 
   #ifdef ESP8266_AT_CLIENT_DEBUG_ECHO_EVERYTHING
       if(debugStream != NULL && debugEnabled) debugStream->println((uint8_t) chr, HEX); // echo the received characters to the Serial Monitor
@@ -1609,10 +1642,12 @@ boolean ESP8266_AT_Client::setNetworkMode(uint8_t mode){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1660,21 +1695,23 @@ boolean ESP8266_AT_Client::connectToNetwork(char * ssid, char * pwd, int32_t tim
   while(!error_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-      if(wifi_is_connected){
-        got_connected = true;
-      }
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+        if(wifi_is_connected){
+          got_connected = true;
+        }
 
-      if(ok_flag){
-        got_ok = true;
-      }
+        if(ok_flag){
+          got_ok = true;
+        }
 
-      if(wifi_is_connected && got_ok){
-        break;
-      }
-    }          
+        if(wifi_is_connected && got_ok){
+          break;
+        }
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1708,21 +1745,23 @@ boolean ESP8266_AT_Client::disconnectFromNetwork(){
   while(!error_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis; 
-      if(!wifi_is_connected){
-        got_disonnected = true;
-      }
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis; 
+        if(!wifi_is_connected){
+          got_disonnected = true;
+        }
 
-      if(ok_flag){
-        got_ok = true;
-      }
+        if(ok_flag){
+          got_ok = true;
+        }
 
-      if(got_disonnected && got_ok){
-        break;
-      }
-    }          
+        if(got_disonnected && got_ok){
+          break;
+        }
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1834,58 +1873,60 @@ boolean ESP8266_AT_Client::firmwareUpdateBegin(){
   while(!error_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;     
-      // mini-state machine looking for +CIPUPDATE:1 
-      //                                0123456789ab
-      switch(last_character_received){
-      case ' ': 
-        if(b == '+'){ last_character_received = b; pursuit_depth = 1; }   
-        break;     
-      case '+':
-        if(b == 'C'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;
-      case 'C':
-        if(b == 'I'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case 'I':
-        if(b == 'P'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case 'P':
-        if((b == 'U') && (pursuit_depth == 4)){ last_character_received = b; pursuit_depth ++; }        
-        else if((b == 'D') && (pursuit_depth == 6)){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;     
-      case 'D':
-        if(b == 'A'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case 'A':
-        if(b == 'T'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case 'T':
-        if(b == 'E'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case 'E':
-        if(b == ':'){ last_character_received = b; pursuit_depth ++; }        
-        else { last_character_received = ' '; }
-        break;    
-      case ':':
-        if(b == '1'){ 
-          got_plus_cipupdate_colon_1 = true;
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;     
+        // mini-state machine looking for +CIPUPDATE:1 
+        //                                0123456789ab
+        switch(last_character_received){
+        case ' ': 
+          if(b == '+'){ last_character_received = b; pursuit_depth = 1; }   
+          break;     
+        case '+':
+          if(b == 'C'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
           break;
-        }        
-        last_character_received = ' '; // unconditional, goal state
-        break;                                                      
-      // no default state, on purpose
-      }
-    }          
+        case 'C':
+          if(b == 'I'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case 'I':
+          if(b == 'P'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case 'P':
+          if((b == 'U') && (pursuit_depth == 4)){ last_character_received = b; pursuit_depth ++; }        
+          else if((b == 'D') && (pursuit_depth == 6)){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;     
+        case 'D':
+          if(b == 'A'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case 'A':
+          if(b == 'T'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case 'T':
+          if(b == 'E'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case 'E':
+          if(b == ':'){ last_character_received = b; pursuit_depth ++; }        
+          else { last_character_received = ' '; }
+          break;    
+        case ':':
+          if(b == '1'){ 
+            got_plus_cipupdate_colon_1 = true;
+            break;
+          }        
+          last_character_received = ' '; // unconditional, goal state
+          break;                                                      
+        // no default state, on purpose
+        }
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1913,10 +1954,12 @@ boolean ESP8266_AT_Client::firmwareUpdateStatus(uint8_t * status){
   while(!error_flag && !ok_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -1972,24 +2015,26 @@ boolean ESP8266_AT_Client::getVersion(char * version){
   while(!error_flag && !ok_to_exit && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;   
-      if(b == ':'){
-        got_colon = true;
-      }
-      else if(b == '('){
-        got_paren = true;
-        extracted_version = true;
-      }
-
-      if((b != ':') && got_colon && !got_paren){
-        if(write_idx < 15){ // [15] is the last available space
-          version[write_idx++] = b;
-          version[write_idx] = '\0';
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;   
+        if(b == ':'){
+          got_colon = true;
         }
-      }
-    }          
+        else if(b == '('){
+          got_paren = true;
+          extracted_version = true;
+        }
+
+        if((b != ':') && got_colon && !got_paren){
+          if(write_idx < 15){ // [15] is the last available space
+            version[write_idx++] = b;
+            version[write_idx] = '\0';
+          }
+        }
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -2066,10 +2111,12 @@ boolean ESP8266_AT_Client::restoreDefault(){
   while(!error_flag && !ready_flag && !timeout_flag){
     current_millis = millis();
 
-    int16_t b = streamReadChar();
-    if(b > 0){
-      previous_millis = current_millis;      
-    }          
+    if(stream->available() > 0){
+      int16_t b = streamReadChar();
+      if(b > 0){
+        previous_millis = current_millis;      
+      }          
+    }
 
     if (current_millis - previous_millis >= interval) {
       timeout_flag = true;
@@ -2150,35 +2197,40 @@ size_t ESP8266_AT_Client::streamWrite(const uint8_t *buf, size_t sz){
 int16_t ESP8266_AT_Client::streamReadChar(void){
   if(numIncomingBytesPending > 0){
     processIncomingAfterColon();
-    return -1;
+    return -1; // ask the caller to try again    
   }
   else {
-    if(stream->available() == 0){
-      return -1;
-    }
-
-    int16_t b = stream->read() & 0xff;
-    addToDebugReadWindow(b);
-#if defined(ESP8266_AT_CLIENT_DEBUG_INCOMING)
-    if(debugEnabled){
-      if(isprint(b) || isspace(b)) Serial.print((char) b);
-      else{
-        Serial.print(" 0x");
-        if(b < 0x10) Serial.print('0');
-        Serial.println(b, HEX);
+    if(stream->available()){
+      int16_t b = stream->read() & 0xff;
+      addToDebugReadWindow(b);
+  #if defined(ESP8266_AT_CLIENT_DEBUG_INCOMING)
+      if(debugEnabled){
+        if(isprint(b) || isspace(b)) Serial.print((char) b);
+        else{
+          Serial.print(" 0x");
+          if(b < 0x10) Serial.print('0');
+          Serial.println(b, HEX);
+        }
       }
-    }
-#endif
+  #endif
 
-    if(updatePlusIpdState(b)){
-      processIncomingUpToColon(); 
-      processIncomingAfterColon(); // try immediately, but don't block
-      return -1; // -1 is distinguishable from consumable data to the caller
-                // because return type is artificially int16_t (not uint16_t)
+      if(updatePlusIpdState(b)){
+        processIncomingUpToColon(); 
+        processIncomingAfterColon(); // try immediately, but don't block
+        return -1; // -1 is distinguishable from consumable data to the caller
+                  // because return type is artificially int16_t (not uint16_t)
+      }
+      else{
+        return b;
+      }    
     }
-    else{
-      return b;
-    }    
+    else {
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)                   
+        Serial.println("PANIC35");
+        printDebugWindow();
+#endif            
+      return -1; // don't ask the stream
+    }
   }
 }
 
@@ -2192,7 +2244,7 @@ int16_t ESP8266_AT_Client::streamReadChar(void){
 // that number tells you how many bytes will be received
 // then you get a colon delimeter
 // then you should get exactly that many bytes reported
-void ESP8266_AT_Client::processIncomingUpToColon(void){
+void ESP8266_AT_Client::processIncomingUpToColon(void){  
   // timeout after 500ms of inactivity
   uint32_t current_time = millis();    
   uint32_t previous_time = current_time;
@@ -2227,7 +2279,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
       current_time = millis();          
       bytesAvailable--;
       previous_time = current_time;
-      unsigned char b = stream->read() & 0xff;    
+      int16_t b = stream->read() & 0xff;    
       addToDebugReadWindow(b);
 #if defined(ESP8266_AT_CLIENT_DEBUG_INCOMING)      
       if(debugEnabled){
@@ -2276,32 +2328,37 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
 
   // if we got to here, we've received a colon and _should_ be able to parse
   // the contents of num_bytes_str into a number which we can store in num_bytes_expected
-  // lets give it a shot    
-  char * temp;
-  numIncomingBytesPending = strtoul(&num_bytes_str[0], &temp, 10);
-  if (*temp != '\0'){
-    // TODO: complain loudly if this happens
-#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)               
-    Serial.println("PANIC3");
-    Serial.print("num_bytes_str was \"");
-    Serial.print(num_bytes_str);
-    Serial.println("\"");
-    for(uint16_t ii = 0; ii < strlen(num_bytes_str); ii++){
-      uint8_t b = num_bytes_str[ii];
-      if(isprint(b) || isspace(b)){
-        Serial.print((char) b);
-      }
-      else{
-        Serial.print(" 0x");
-        if(b < 0x10) Serial.print('0');
-        Serial.print(b, HEX);
-      }
-    }
-    printDebugWindow();
-#endif    
-    numIncomingBytesPending = 0;
-    return; // failed to parse length
-  }
+  // lets give it a shot   
+  numIncomingBytesPending = atoi(num_bytes_str);
+
+  // Serial.print(numIncomingBytesPending);
+  // Serial.println(" Bytes Incoming");
+  
+//   char * temp;
+//   numIncomingBytesPending = strtoul(num_bytes_str, &temp, 10);
+//   if (*temp != '\0'){
+//     // TODO: complain loudly if this happens
+// #if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)               
+//     Serial.println("PANIC3");
+//     Serial.print("num_bytes_str was \"");
+//     Serial.print(num_bytes_str);
+//     Serial.println("\"");
+//     for(uint16_t ii = 0; ii < strlen(num_bytes_str); ii++){
+//       uint8_t b = num_bytes_str[ii];
+//       if(isprint(b) || isspace(b)){
+//         Serial.print((char) b);
+//       }
+//       else{
+//         Serial.print(" 0x");
+//         if(b < 0x10) Serial.print('0');
+//         Serial.print(b, HEX);
+//       }
+//     }
+//     printDebugWindow();
+// #endif    
+//     numIncomingBytesPending = 0;
+//     return; // failed to parse length
+//   }
 }
 
 // this function should be the only other one besides streamReadChar that
@@ -2328,11 +2385,14 @@ boolean ESP8266_AT_Client::processIncomingAfterColon(void){
     }
 #endif    
 
-    while(bytesAvailable > 0){
-      bytesAvailable--;
-
-      uint8_t b = stream->read() & 0xff;
+    while(bytesAvailable > 0){      
+  
+      int16_t b = stream->read() & 0xff;
       addToDebugReadWindow(b);
+
+      bytesAvailable--;
+      numIncomingBytesPending--;
+      ret = true; // true we read some bytes from stream
 
 #if defined(ESP8266_AT_CLIENT_DEBUG_INCOMING)      
       if(debugEnabled){        
@@ -2345,18 +2405,14 @@ boolean ESP8266_AT_Client::processIncomingAfterColon(void){
       }
 #endif
 
-      if(writeToInputBuffer(b)){
-        ret = true;
-        numIncomingBytesPending--;
-      }
-      else {
+      if(!writeToInputBuffer(b)){
         // TODO: complain _really_ loudly if this happens      
 #if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)              
         Serial.println("PANIC4");
         printDebugWindow();
         numIncomingBytesPending = 0; // the transfer has failed
 #endif        
-        return false; // out of space in application buffer                
+        break; // out of space in application buffer                
       }
 
       if(numIncomingBytesPending == 0){
@@ -2366,8 +2422,14 @@ boolean ESP8266_AT_Client::processIncomingAfterColon(void){
       }
     }
   }
-
-  return ret;
+  // else {
+  //   // there are no bytes pending
+  //   // ret will be false
+  // }
+  
+  return ret; 
+  // ret is true if an only if 
+  //   at least one byte was put into the application data input buffer
 }
 
 // this should get called _before_ any AT communication to the ESP8266
@@ -2377,14 +2439,17 @@ void ESP8266_AT_Client::waitForIncomingDataToComplete(void){
   uint32_t current_time = millis();    
   uint32_t previous_time = current_time;
   const int32_t timeout_interval = 500;  // signed for comparison / overflow  
-  boolean dataWasIncoming = numIncomingBytesPending > 0;
+
+  boolean dataWasIncoming = (numIncomingBytesPending > 0);
   while(numIncomingBytesPending > 0){
     current_time = millis();
+
     boolean gotData = processIncomingAfterColon(); // decrements numIncomingBytesPending
     if(gotData){
       previous_time = current_time;
     }
-    else if (current_time - previous_time >= timeout_interval){
+    
+    if (current_time - previous_time >= timeout_interval){
       // TODO: complain _really_ loudly if this happens
 #if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)            
       Serial.println("PANIC5");

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -248,7 +248,6 @@ int ESP8266_AT_Client::connect(const char *host, uint16_t port, esp8266_connect_
 
   int ret = 2; // initialize to error
   socket_connected = false;
-  wifi_is_connected = false;
   listener_started = false;
 
   ESP8266_DEBUG("Connecting to ", (char *) host);
@@ -1512,8 +1511,7 @@ boolean ESP8266_AT_Client::connectToNetwork(char * ssid, char * pwd, int32_t tim
   streamWrite("\r\n");
 
   // wait for connected status
-  if(readStreamUntil("WIFI CONNECTED", timeout_ms, false)){
-
+  if(readStreamUntil("WIFI CONNECTED", timeout_ms, false)){  
     ESP8266_DEBUG("Connected to Network");
     if(onConnect != NULL){
       onConnect();
@@ -1523,19 +1521,23 @@ boolean ESP8266_AT_Client::connectToNetwork(char * ssid, char * pwd, int32_t tim
        ESP8266_DEBUG("Got IP");
 
        if(readStreamUntil("OK")){
+         wifi_is_connected = true;
          return true;
        }
     }
     else{
        ESP8266_DEBUG("Failed to get IP address");
+       wifi_is_connected = false;
        return false;
     }
   }
   else{
      ESP8266_DEBUG("Failed to connect to Network");
+     wifi_is_connected = false;
      return false;
   }
 
+  wifi_is_connected = false;
   return false;
 }
 

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -2281,6 +2281,7 @@ boolean ESP8266_AT_Client::updatePlusIpdState(uint8_t chr){
         if(c == 'T') { 
           // this is a goal state
           wifi_is_connected = false;
+          socket_connected = false; // that too
         }
         // unconditionally clear the state machine after 'T'
         pursuitString = 0; lastCharAccepted = ' ';

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -1800,7 +1800,7 @@ size_t ESP8266_AT_Client::streamWrite(const uint8_t *buf, size_t sz){
   size_t bytes_written = 0;
   Serial.print("SEND B: ");  
   Serial.print(sz);   
-  for(uint8_t ii = 0; ii < sz; ii++){
+  for(uint16_t ii = 0; ii < sz; ii++){
     uint8_t b = buf[ii] & 0xff;        
     Serial.print(" 0x");
     if(b < 0x10) Serial.print('0');

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -753,6 +753,12 @@ size_t ESP8266_AT_Client::write(const uint8_t *buf, size_t sz){
     }
   }
   
+  // NOTE: this next bit is 'magic bullet'
+  //       sometimes sending doesn't pick up the expected event sequence
+  //       so... if you go through all that and timeout without writing
+  //       just go ahead and write anyway and hope for the best
+  //       and this actually seems to work reliably
+
   // don't leave the ESP hanging waiting for data
   if((ret < sz) && timeout_flag){
     ret = streamWrite(buf + ret, sz - ret); 

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -771,6 +771,12 @@ size_t ESP8266_AT_Client::write(const uint8_t *buf, size_t sz){
   // Serial.println(ret);
   // Serial.println();
 
+  // datasheet actually says: 
+  // Enter transparent transmission, with a 20-ms
+  // interval between each packet, and a maximum of
+  // 2048 bytes per packet.
+  delay(25); // minimum 20ms, lets be generous
+
   // should return the number of bytes written
   return ret;
 }
@@ -2234,9 +2240,10 @@ size_t ESP8266_AT_Client::streamWrite(const uint8_t *buf, size_t sz){
       bytes_written++;
       buf++;
 
-      if((bytes_written % 32) == 0){
-        delay(10); // maybe don't flood the ESP8266 with bytes?
-      }
+      // NOTE: removing the following in favor of a 20ms delay _after_ CIPSEND completes
+      // if((bytes_written % 32) == 0){
+      //   delay(10); // maybe don't flood the ESP8266 with bytes?
+      // }
     }    
   }  
 

--- a/ESP8266_AT_Client.cpp
+++ b/ESP8266_AT_Client.cpp
@@ -4,7 +4,9 @@
 
 // #define ESP8266_AT_CLIENT_ENABLE_DEBUG
 // #define ESP8266_AT_CLIENT_DEBUG_ECHO_EVERYTHING
-#define ESP8266_AT_CLIENT_DEBUG_INCOMING
+// #define ESP8266_AT_CLIENT_DEBUG_OUTGOING
+// #define ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES
+// #define ESP8266_AT_CLIENT_DEBUG_INCOMING
 
 static uint16_t ESP8266_AT_Client::bytesAvailableMax = 0;
 #if defined(ESP8266_AT_CLIENT_DEBUG_INCOMING)
@@ -174,9 +176,12 @@ boolean ESP8266_AT_Client::reset(void){
     ESP8266_DEBUG("Received 'ready'");
   }
   else{
-    ESP8266_DEBUG("Panic");
+
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)        
     Serial.println("PANIC6");
     printDebugWindow();
+#endif
+
     return false;
   }
 
@@ -570,11 +575,13 @@ int ESP8266_AT_Client::available(){
     ESP8266_AT_Client::bytesAvailableMax = bytesAvailable;
   }
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)            
   if(bytesAvailable > 50){
     // TODO: complain loudly if this happens 
     Serial.println("PANIC13");      
     printDebugWindow();
   }        
+#endif    
 
   if(bytesAvailable > 0){
     while(stream->available()){    
@@ -1231,11 +1238,13 @@ boolean ESP8266_AT_Client::readStreamUntil(uint8_t * match_idx, char * target_bu
       ESP8266_AT_Client::bytesAvailableMax = bytesAvailable;
     }    
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)        
     if(bytesAvailable > 50){
       // TODO: complain loudly if this happens 
       Serial.println("PANIC11");      
       printDebugWindow();
     }
+#endif
 
     if(bytesAvailable > 0){
 
@@ -1317,6 +1326,7 @@ boolean ESP8266_AT_Client::readStreamUntil(uint8_t * match_idx, char * target_bu
   // delayMicroseconds(10); // i'm not sure why, but it's more well behaved with this delay injected
                          // one theory is that it gives the Serial output time to clear?
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)            
   if(!match_found){
     Serial.println("PANIC7");
     Serial.println("+++");
@@ -1331,6 +1341,7 @@ boolean ESP8266_AT_Client::readStreamUntil(uint8_t * match_idx, char * target_bu
     Serial.println("===");   
     printDebugWindow(); 
   }
+#endif  
                          
   return match_found;
 }
@@ -1438,11 +1449,13 @@ void ESP8266_AT_Client::flushInput(){
     ESP8266_AT_Client::bytesAvailableMax = bytesAvailable;
   }      
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)           
   if(bytesAvailable > 50){
     // TODO: complain loudly if this happens 
     Serial.println("PANIC12");      
     printDebugWindow();
   } 
+#endif
 
   if(bytesAvailable > 0){  
     while(stream->available() > 0){    
@@ -1771,33 +1784,41 @@ boolean ESP8266_AT_Client::restoreDefault(){
 }
 
 size_t ESP8266_AT_Client::streamWrite(const char * str){
+#if defined(ESP8266_AT_CLIENT_DEBUG_OUTGOING)
   Serial.print("SEND S: ");
   Serial.println(str);
+#endif  
   return streamWrite((uint8_t * ) str, strlen(str));
 }
 
 size_t ESP8266_AT_Client::streamWrite(int32_t value){
   char str[16] = {0};
   ltoa(value, str, 10);
+#if defined(ESP8266_AT_CLIENT_DEBUG_OUTGOING)  
   Serial.print("SEND L: ");
   Serial.print(value);  
   Serial.print(' ');
   Serial.println(str);
+#endif  
   return streamWrite((uint8_t * ) str, strlen(str));
 }
 
 size_t ESP8266_AT_Client::streamWrite(uint32_t value){
   char str[16] = {0};
   ultoa(value, str, 10);
+#if defined(ESP8266_AT_CLIENT_DEBUG_OUTGOING)  
   Serial.print("SEND UL: ");
   Serial.print(value);  
   Serial.print(' ');
   Serial.println(str);  
+#endif  
   return streamWrite((uint8_t * ) str, strlen(str));
 }
 
 size_t ESP8266_AT_Client::streamWrite(const uint8_t *buf, size_t sz){    
   size_t bytes_written = 0;
+
+#if defined(ESP8266_AT_CLIENT_DEBUG_OUTGOING)  
   Serial.print("SEND B: ");  
   Serial.print(sz);   
   for(uint16_t ii = 0; ii < sz; ii++){
@@ -1807,6 +1828,7 @@ size_t ESP8266_AT_Client::streamWrite(const uint8_t *buf, size_t sz){
     Serial.print(b, HEX);    
   }
   Serial.println();
+#endif  
 
   while(sz > 0){
     size_t availableForWrite = streamAsPrint->availableForWrite();
@@ -1891,11 +1913,13 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
       ESP8266_AT_Client::bytesAvailableMax = bytesAvailable;
     }     
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)           
     if(bytesAvailable > 50){
       // TODO: complain loudly if this happens 
       Serial.println("PANIC9");      
       printDebugWindow();
     }
+#endif    
     
     while((bytesAvailable > 0) && !gotColon){
       bytesAvailable--;
@@ -1927,15 +1951,21 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
       }
       else{
         // TODO: complain loudly if this happens
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)                   
         Serial.println("PANIC1");
         printDebugWindow();
+#endif  
+
         return; // overflow
       }
 
       if (!gotColon && (current_time - previous_time >= timeout_interval)){
         // TODO: complain loudly if this happens      
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)                   
         Serial.println("PANIC2");
         printDebugWindow();
+#endif
+
         return; // timeout
       }
     }
@@ -1948,6 +1978,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
   numIncomingBytesPending = strtoul(&num_bytes_str[0], &temp, 10);
   if (*temp != '\0'){
     // TODO: complain loudly if this happens
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)               
     Serial.println("PANIC3");
     Serial.print("num_bytes_str was \"");
     Serial.print(num_bytes_str);
@@ -1964,6 +1995,7 @@ void ESP8266_AT_Client::processIncomingUpToColon(void){
       }
     }
     printDebugWindow();
+#endif    
     numIncomingBytesPending = 0;
     return; // failed to parse length
   }
@@ -1985,11 +2017,13 @@ boolean ESP8266_AT_Client::processIncomingAfterColon(void){
       ESP8266_AT_Client::bytesAvailableMax = bytesAvailable;
     }     
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)      
     if(bytesAvailable > 50){
       // TODO: complain loudly if this happens 
       Serial.println("PANIC10");      
       printDebugWindow();
     }
+#endif    
 
     while(bytesAvailable > 0){
       bytesAvailable--;
@@ -2014,9 +2048,11 @@ boolean ESP8266_AT_Client::processIncomingAfterColon(void){
       }
       else {
         // TODO: complain _really_ loudly if this happens      
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)              
         Serial.println("PANIC4");
         printDebugWindow();
         numIncomingBytesPending = 0; // the transfer has failed
+#endif        
         return false; // out of space in application buffer                
       }
 
@@ -2047,8 +2083,11 @@ void ESP8266_AT_Client::waitForIncomingDataToComplete(void){
     }
     else if (current_time - previous_time >= timeout_interval){
       // TODO: complain _really_ loudly if this happens
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)            
       Serial.println("PANIC5");
       printDebugWindow();
+#endif
+      
       // probably the connection is lost
       socket_connected = false;
       numIncomingBytesPending = 0; // give up
@@ -2057,11 +2096,14 @@ void ESP8266_AT_Client::waitForIncomingDataToComplete(void){
     }
   }
 
+#if defined(ESP8266_AT_CLIENT_ENABLE_PANIC_MESSAGES)      
   if(dataWasIncoming && (numIncomingBytesPending > 0)){
     // TODO: complain _really_ loudly if this happens
     Serial.println("PANIC8");
     printDebugWindow();
   }
+#endif
+
 }
 
 // this self-contained state machine should be called with _every_ incoming byte

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -120,11 +120,14 @@ private:
   char target_match_array[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1][ESP8266_AT_CLIENT_MAX_STRING_LENGTH + 1];
   char target_match_lengths[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1];
   
-  void handleIncoming(void);             // should be called anytime right after you see +IPD,
+  void processIncomingUpToColon(void);   // should be called anytime right after you see +IPD,
+  boolean processIncomingAfterColon(void);  // should be called frequently (as in non-blocking implementation), while incoming data is pending
+  uint32_t numIncomingBytesPending = 0;  // this should be counted down to zero by processIncomingAfterColon  
   boolean updatePlusIpdState(uint8_t c); // anytime a character is received this should be called with that caracter as an argument 
                                          // returns true if handleIncoming should be called
   int16_t streamReadChar(void);          // should only be called if it is known that there are bytes available
                                          // returns (int16_t) -1 if processing was interrupted by +IPD handling
+  void waitForIncomingDataToComplete(void); // just calls processIncomingAfterColon in a spin loop, with timeout
 
   void clearTargetMatchArray(void);
   boolean writeToInputBuffer(uint8_t c);

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -109,6 +109,9 @@ private:
   boolean socket_connected;
   boolean wifi_is_connected;
   boolean listener_started;
+  boolean ok_flag;
+  boolean error_flag;
+
   esp8266_connect_proto_t socket_type;
   uint16_t tcp_keep_alive_interval_seconds;
 

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -114,6 +114,7 @@ private:
   boolean ok_flag;
   boolean ready_flag;
   boolean error_flag;
+  boolean send_ok_flag;
 
   esp8266_connect_proto_t socket_type;
   uint16_t tcp_keep_alive_interval_seconds;

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -107,6 +107,7 @@ private:
   boolean debugEnabled;
 
   boolean socket_connected;
+  boolean wifi_is_connected;
   boolean listener_started;
   esp8266_connect_proto_t socket_type;
   uint16_t tcp_keep_alive_interval_seconds;

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -146,17 +146,6 @@ private:
   uint8_t readFromInputBuffer(void);
   void parseScanResult(ap_scan_result_t * result, char * line);
 
-  boolean readStreamUntil(uint8_t * match_idx, char * target_buffer, uint16_t target_buffer_length, int32_t timeout_ms, boolean reset_timeout_on_possible_rx);
-  boolean readStreamUntil(uint8_t * match_idx, char * target_buffer, uint16_t target_buffer_length, int32_t timeout_ms);
-  boolean readStreamUntil(uint8_t * match_idx, int32_t timeout_ms);
-  boolean readStreamUntil(uint8_t * match_idx);
-
-  boolean readStreamUntil(char * target_match, char * target_buffer, uint16_t target_buffer_length, int32_t timeout_ms, boolean reset_timeout_on_possible_rx);
-  boolean readStreamUntil(char * target_match, char * target_buffer, uint16_t target_buffer_length, int32_t timeout_ms);
-  boolean readStreamUntil(char * target_match, int32_t timeout_ms, boolean reset_timeout_on_possible_rx);
-  boolean readStreamUntil(char * target_match, int32_t timeout_ms);
-  boolean readStreamUntil(char * target_match);
-
   void flushInput();
   void ESP8266_DEBUG(char * msg);
   void ESP8266_DEBUG(char * msg, uint16_t value);

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -110,6 +110,7 @@ private:
   boolean wifi_is_connected;
   boolean listener_started;
   boolean ok_flag;
+  boolean ready_flag;
   boolean error_flag;
 
   esp8266_connect_proto_t socket_type;
@@ -123,9 +124,6 @@ private:
   uint8_t * input_buffer_tail_ptr;
   uint16_t num_consumed_bytes_in_input_buffer;
   uint16_t num_free_bytes_in_input_buffer;
-
-  char target_match_array[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1][ESP8266_AT_CLIENT_MAX_STRING_LENGTH + 1];
-  char target_match_lengths[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1];
   
   void processIncomingUpToColon(void);   // should be called anytime right after you see +IPD,
   boolean processIncomingAfterColon(void);  // should be called frequently (as in non-blocking implementation), while incoming data is pending
@@ -141,7 +139,6 @@ private:
   size_t streamWrite(int32_t value);
   size_t streamWrite(const uint8_t *buf, size_t sz); // write a buffer of known size to the stream
   
-  void clearTargetMatchArray(void);
   boolean writeToInputBuffer(uint8_t c);
   uint8_t readFromInputBuffer(void);
   void parseScanResult(ap_scan_result_t * result, char * line);

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -97,6 +97,8 @@ public:
   boolean getVersion(uint32_t * version);
   boolean restoreDefault();
 
+  boolean AT(void);
+
   operator bool();
 
   boolean addStringToTargetMatchList(char * str);
@@ -119,9 +121,9 @@ private:
   uint8_t enable_pin;
   uint8_t * input_buffer;
   uint16_t input_buffer_length;
-  uint8_t * input_buffer_read_ptr;
-  uint8_t * input_buffer_write_ptr;
-  uint8_t * input_buffer_tail_ptr;
+  uint16_t input_buffer_read_idx;
+  uint16_t input_buffer_write_idx;
+
   uint16_t num_consumed_bytes_in_input_buffer;
   uint16_t num_free_bytes_in_input_buffer;
   
@@ -140,7 +142,7 @@ private:
   size_t streamWrite(const uint8_t *buf, size_t sz); // write a buffer of known size to the stream
   
   boolean writeToInputBuffer(uint8_t c);
-  uint8_t readFromInputBuffer(void);
+  int16_t readFromInputBuffer(void);
   void parseScanResult(ap_scan_result_t * result, char * line);
 
   void flushInput();

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -127,7 +127,7 @@ private:
   
   void processIncomingUpToColon(void);   // should be called anytime right after you see +IPD,
   boolean processIncomingAfterColon(void);  // should be called frequently (as in non-blocking implementation), while incoming data is pending
-  uint32_t numIncomingBytesPending = 0;  // this should be counted down to zero by processIncomingAfterColon  
+  int32_t numIncomingBytesPending = 0;  // this should be counted down to zero by processIncomingAfterColon  
   boolean updatePlusIpdState(uint8_t c); // anytime a character is received this should be called with that caracter as an argument 
                                          // returns true if handleIncoming should be called
   int16_t streamReadChar(void);          // should only be called if it is known that there are bytes available

--- a/ESP8266_AT_Client.h
+++ b/ESP8266_AT_Client.h
@@ -102,7 +102,6 @@ private:
   Stream * stream;      // where AT commands are sent and responses received
   Stream * debugStream; // where Debug messages go
   boolean debugEnabled;
-  enum {WAITING_FOR_IPD, WAITING_FOR_IPD_OR_CLOSED, WAITING_FOR_COLON, PROCESSING_IPD} receive_state;
 
   boolean socket_connected;
   boolean listener_started;
@@ -118,9 +117,14 @@ private:
   uint16_t num_consumed_bytes_in_input_buffer;
   uint16_t num_free_bytes_in_input_buffer;
 
-  uint16_t num_characters_remaining_to_receive;
   char target_match_array[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1][ESP8266_AT_CLIENT_MAX_STRING_LENGTH + 1];
   char target_match_lengths[ESP8266_AT_CLIENT_MAX_NUM_TARGET_MATCHES + 1];
+  
+  void handleIncoming(void);             // should be called anytime right after you see +IPD,
+  boolean updatePlusIpdState(uint8_t c); // anytime a character is received this should be called with that caracter as an argument 
+                                         // returns true if handleIncoming should be called
+  int16_t streamReadChar(void);          // should only be called if it is known that there are bytes available
+                                         // returns (int16_t) -1 if processing was interrupted by +IPD handling
 
   void clearTargetMatchArray(void);
   boolean writeToInputBuffer(uint8_t c);
@@ -139,7 +143,6 @@ private:
   boolean readStreamUntil(char * target_match);
 
   void flushInput();
-  void receive(boolean delegate_received_IPD = 0);
   void ESP8266_DEBUG(char * msg);
   void ESP8266_DEBUG(char * msg, uint16_t value);
   void ESP8266_DEBUG(char * msg, char * value);


### PR DESCRIPTION
This PR combines many changes to the library in order to rely on passive detection of status events rather than polling interrogation of the ESP module for status. The refactor also eliminates the readStreamUntil construct entirely in favor of a simpler flag based stream parsing. Result is much better handling of incoming packet data. Other vitally important improvement in the new implementation is respect for the 20 ms delay between packets, and doing so in a way that continues to service incoming packet data.